### PR TITLE
Fix Home Page to navigate demo page

### DIFF
--- a/lib/counter/counter_page.dart
+++ b/lib/counter/counter_page.dart
@@ -5,13 +5,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'counter_notifier.dart';
 
 class CounterPage extends ConsumerWidget {
+  static const title = 'Counter with Riverpod';
+  static const route = '/counter';
+
   const CounterPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final counter = ref.watch(counterNotifierProvider);
     return CounterTemplate(
-      title: 'Counter with Riverpod',
+      title: title,
       message: 'You have pushed the button this many times:',
       counter: counter,
       onPressedIncrementButton: (() => _incrementCounter(ref)),

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -22,7 +22,9 @@ class HomePage extends StatelessWidget {
       title: 'Counter',
       onTapListItem: (context) => Navigator.push(
         context,
-        MaterialPageRoute(builder: (context) => const CounterPage()),
+        MaterialPageRoute(
+          builder: (context) => const CounterPage(),
+        ),
       ),
     );
   }

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -8,6 +8,24 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      routes: {
+        '/': (context) => const _HomePage(),
+        CounterPage.route: (context) => const CounterPage(),
+      },
+    );
+  }
+}
+
+class _HomePage extends StatelessWidget {
+  const _HomePage();
+
+  @override
+  Widget build(BuildContext context) {
     return HomeTemplate(
       props: HomeProps(
         title: 'Home',

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_demo/counter/counter_page.dart';
+import 'package:flutter_demo/home/home_props.dart';
+import 'package:flutter_demo/home/home_template.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return HomeTemplate(
+        props: HomeProps(
+      title: 'Home',
+      items: [
+        _counterListItemProps(context),
+      ],
+    ));
+  }
+
+  HomeListItemProps _counterListItemProps(BuildContext context) {
+    return HomeListItemProps(
+      title: 'Counter',
+      onTapListItem: (context) => Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => const CounterPage()),
+      ),
+    );
+  }
+}

--- a/lib/home/home_page.dart
+++ b/lib/home/home_page.dart
@@ -9,23 +9,20 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return HomeTemplate(
-        props: HomeProps(
-      title: 'Home',
-      items: [
-        _counterListItemProps(context),
-      ],
-    ));
+      props: HomeProps(
+        title: 'Home',
+        items: [
+          _counterListItemProps(context),
+        ],
+      ),
+      onTapListItem: (context, route) => Navigator.pushNamed(context, route),
+    );
   }
 
   HomeListItemProps _counterListItemProps(BuildContext context) {
     return HomeListItemProps(
-      title: 'Counter',
-      onTapListItem: (context) => Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => const CounterPage(),
-        ),
-      ),
+      title: CounterPage.title,
+      route: CounterPage.route,
     );
   }
 }

--- a/lib/home/home_props.dart
+++ b/lib/home/home_props.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class HomeProps {
+  final String title;
+  final List<HomeListItemProps> items;
+
+  HomeProps({
+    required this.title,
+    required this.items,
+  });
+}
+
+class HomeListItemProps {
+  final String title;
+  final void Function(BuildContext context) onTapListItem;
+
+  HomeListItemProps({
+    required this.title,
+    required this.onTapListItem,
+  });
+}

--- a/lib/home/home_props.dart
+++ b/lib/home/home_props.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 class HomeProps {
   final String title;
   final List<HomeListItemProps> items;
@@ -12,10 +10,10 @@ class HomeProps {
 
 class HomeListItemProps {
   final String title;
-  final void Function(BuildContext context) onTapListItem;
+  final String route;
 
   HomeListItemProps({
     required this.title,
-    required this.onTapListItem,
+    required this.route,
   });
 }

--- a/lib/home/home_template.dart
+++ b/lib/home/home_template.dart
@@ -29,6 +29,7 @@ class HomeTemplate extends StatelessWidget {
 
   Widget _buildListItem(BuildContext context, HomeListItemProps item) {
     return Card(
+      key: Key('homeListItem${item.title}'),
       child: ListTile(
         title: Text(item.title),
         onTap: () => item.onTapListItem(context),

--- a/lib/home/home_template.dart
+++ b/lib/home/home_template.dart
@@ -3,10 +3,12 @@ import 'package:flutter_demo/home/home_props.dart';
 
 class HomeTemplate extends StatelessWidget {
   final HomeProps props;
+  final void Function(BuildContext, String route) onTapListItem;
 
   const HomeTemplate({
     super.key,
     required this.props,
+    required this.onTapListItem,
   });
 
   @override
@@ -22,17 +24,17 @@ class HomeTemplate extends StatelessWidget {
   Widget _buildList(BuildContext context) {
     return ListView.builder(
       itemCount: props.items.length,
-      itemBuilder: (context, index) =>
-          _buildListItem(context, props.items[index]),
+      itemBuilder: _buildListItem,
     );
   }
 
-  Widget _buildListItem(BuildContext context, HomeListItemProps item) {
+  Widget _buildListItem(BuildContext context, int index) {
+    final item = props.items[index];
     return Card(
-      key: Key('homeListItem${item.title}'),
+      key: Key('home_list_item_$index'),
       child: ListTile(
         title: Text(item.title),
-        onTap: () => item.onTapListItem(context),
+        onTap: () => onTapListItem(context, item.route),
       ),
     );
   }

--- a/lib/home/home_template.dart
+++ b/lib/home/home_template.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_demo/home/home_props.dart';
+
+class HomeTemplate extends StatelessWidget {
+  final HomeProps props;
+
+  const HomeTemplate({
+    super.key,
+    required this.props,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(props.title),
+      ),
+      body: _buildList(context),
+    );
+  }
+
+  Widget _buildList(BuildContext context) {
+    return ListView.builder(
+      itemCount: props.items.length,
+      itemBuilder: (context, index) =>
+          _buildListItem(context, props.items[index]),
+    );
+  }
+
+  Widget _buildListItem(BuildContext context, HomeListItemProps item) {
+    return Card(
+      child: ListTile(
+        title: Text(item.title),
+        onTap: () => item.onTapListItem(context),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_demo/home/home_page.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'counter/counter_page.dart';
+
 void main() {
   runApp(const ProviderScope(child: MyApp()));
 }
@@ -16,7 +18,10 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const HomePage(),
+      routes: {
+        '/': (context) => const HomePage(),
+        CounterPage.route: (context) => const CounterPage(),
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,26 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_demo/home/home_page.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'counter/counter_page.dart';
-
 void main() {
-  runApp(const ProviderScope(child: MyApp()));
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
-      routes: {
-        '/': (context) => const HomePage(),
-        CounterPage.route: (context) => const CounterPage(),
-      },
-    );
-  }
+  runApp(const ProviderScope(child: HomePage()));
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_demo/counter/counter_page.dart';
+import 'package:flutter_demo/home/home_page.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 void main() {
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const CounterPage(),
+      home: const HomePage(),
     );
   }
 }

--- a/test/home/home_page_test.dart
+++ b/test/home/home_page_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_demo/counter/counter_page.dart';
+import 'package:flutter_demo/home/home_page.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Counter page', (() {
+    const counterPageLinkItemKey = Key('homeListItemCounter');
+
+    testWidgets('''
+      Home page has counter page link item.
+    ''', (tester) async {
+      await tester.pumpWidget(_buildTestWidget());
+
+      expect(find.byKey(counterPageLinkItemKey), findsOneWidget);
+    });
+
+    testWidgets('''
+      When tap counter page link item,
+      then navigate to counter page.
+    ''', (tester) async {
+      await tester.pumpWidget(_buildTestWidget());
+
+      await tester.tap(find.byKey(counterPageLinkItemKey));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CounterPage), findsOneWidget);
+    });
+  }));
+}
+
+Widget _buildTestWidget() {
+  return const ProviderScope(child: MaterialApp(home: HomePage()));
+}

--- a/test/home/home_page_test.dart
+++ b/test/home/home_page_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_demo/counter/counter_page.dart';
-import 'package:flutter_demo/main.dart';
+import 'package:flutter_demo/home/home_page.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -31,5 +31,5 @@ void main() {
 }
 
 Widget _buildTestWidget() {
-  return const ProviderScope(child: MyApp());
+  return const ProviderScope(child: HomePage());
 }

--- a/test/home/home_page_test.dart
+++ b/test/home/home_page_test.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_demo/counter/counter_page.dart';
-import 'package:flutter_demo/home/home_page.dart';
+import 'package:flutter_demo/main.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Counter page', (() {
-    const counterPageLinkItemKey = Key('homeListItemCounter');
+    const counterPageLinkItemKey = Key('home_list_item_0');
 
     testWidgets('''
       Home page has counter page link item.
@@ -31,5 +31,5 @@ void main() {
 }
 
 Widget _buildTestWidget() {
-  return const ProviderScope(child: MaterialApp(home: HomePage()));
+  return const ProviderScope(child: MyApp());
 }


### PR DESCRIPTION
### Description

- Fix Home Page to navigate demo page
- Home Page use navigating with named routes
- Home Page route widget is MaterialApp

### References
- https://docs.flutter.dev/cookbook/navigation/named-routes
